### PR TITLE
chore: お試し用のworkflow追加

### DIFF
--- a/.github/workflows/test-required-workflow.yml
+++ b/.github/workflows/test-required-workflow.yml
@@ -1,0 +1,29 @@
+# Org横断でworkflowを必須にできるかを試すためのworkflowです
+# 試し終わったら消します
+name: Test Workflow
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run test
+        run: echo "Test workflow is running successfully!"
+
+      - name: Display system information
+        run: |
+          echo "Operating System: $(uname -s)"
+          echo "Kernel Version: $(uname -r)"
+          echo "Architecture: $(uname -m)"

--- a/.github/workflows/test-required-workflow.yml
+++ b/.github/workflows/test-required-workflow.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run test
         run: echo "Test workflow is running successfully!"


### PR DESCRIPTION
<!-- GitHub Copilot への依頼事項 :コードレビューを実施してコメントをする際は日本語でお願いします。 -->
## issue <!-- #issue番号を記載してください -->

なし

GitHub Actions pinningの件に関連
組織横断でworkflowを必須にできるかを調査するために、お試し用のworkflowを追加
(調査終わったら消します)

## 変更内容 <!-- 行った変更を簡略に記載してください -->

- お試し用のworkflowを追加
  - これをorgのrulesetで指定して組織横断で強制できるかを試します
※見たところ、組織横断でworkflowを必須にするにはEnterprise契約が必要だという記述を見ましたが、少し古い記事しか見つからなかったので本当か試してみます
※個人のorgでも契約的にruresetの適用ができませんでした

スレッドにもメモを残しています
https://ncdctalk.slack.com/archives/C097AFZ36H1/p1762297379289669?thread_ts=1761732211.579479&cid=C097AFZ36H1

## 確認したこと <!-- 何を以て変更要件を満たしていると判断したかを記載してください -->

## スクリーンショット <!--  変更がわかる画面があれば記載してください -->

## 補足事項 <!-- 補足で説明が必要な場合記載してください -->

## PR時のセルフチェック <!-- PRのセルフチェックをしてください -->
- [ ] 関数や変数の命名は一目で分かるものになってますか？
- [ ] コメントは適切な量で、誰が見ても分かるコメントになってますか？
- [ ] PR内容に関するテストは書きましたか？
- [ ] PR内容に付随する各種ドキュメントは一緒に修正しましたか？
- [ ] IssueをCloseする場合、完了の定義は満たせていますか？
